### PR TITLE
Small Math update

### DIFF
--- a/FAST.yyp
+++ b/FAST.yyp
@@ -287,7 +287,7 @@
     {"CopyToMask":-1,"filePath":"datafiles","resourceVersion":"1.0","name":"thing.py","resourceType":"GMIncludedFile",},
   ],
   "MetaData": {
-    "IDEVersion": "2.3.6.595",
+    "IDEVersion": "2.3.7.606",
   },
   "resourceVersion": "1.4",
   "name": "FAST",

--- a/FAST.yyp
+++ b/FAST.yyp
@@ -48,6 +48,7 @@
     {"id":{"name":"DatabaseExpression","path":"scripts/DatabaseExpression/DatabaseExpression.yy",},"order":1,},
     {"id":{"name":"__FAST_UI_config__","path":"scripts/__FAST_UI_config__/__FAST_UI_config__.yy",},"order":1,},
     {"id":{"name":"string_explode","path":"scripts/string_explode/string_explode.yy",},"order":2,},
+    {"id":{"name":"ats_Vec2","path":"scripts/ats_Vec2/ats_Vec2.yy",},"order":1,},
     {"id":{"name":"Parser","path":"scripts/Parser/Parser.yy",},"order":3,},
     {"id":{"name":"ease_in_sine","path":"scripts/ease_in_sine/ease_in_sine.yy",},"order":1,},
     {"id":{"name":"ease_in_elastic","path":"scripts/ease_in_elastic/ease_in_elastic.yy",},"order":0,},

--- a/scripts/Vec2/Vec2.gml
+++ b/scripts/Vec2/Vec2.gml
@@ -6,94 +6,128 @@
 //var _vec2 = new Vec2( 32, 20 );
 /// @output A new Vec2 is created with an x of 32 and a y of 20
 /// @wiki Numbers-Index Constructors
-function Vec2( _x, _y ) constructor {
+function Vec2( _x, _y ) : __Struct__() constructor {
 	/// @param {Vec2} Vec2	A vector
 	/// @desc	Adds this vector to vec and returns the result.
 	/// @returns Vec2
 	static add	= function( _vec ) {
-		return new Vec2( x + _vec.x, y + _vec.y );
-		
+		if (not struct_type(_vec, Vec2)) {
+			throw new UnexpectedTypeMismatch("add", _vec, "Vec2");	
+		}
+		return set(x + _vec.x, y + _vec.y); 
 	}
 	/// @param {Vec2} vec	A vector
 	/// @desc	Substracts this vector from vec and returns the result.
 	/// @returns Vec2
 	static subtract	= function( _vec ) {
-		return new Vec2(  x	- _vec.x, y - _vec.y );
-		
+		if (not struct_type(_vec, Vec2)) {
+			throw new UnexpectedTypeMismatch("subtract", _vec, "Vec2");	
+		}
+		return set(x - _vec.x, y - _vec.y); 
 	}
 	/// @param {Vec2} vec	A vector
 	/// @desc	Multiplies this vector by vec and returns the result.
 	/// @returns Vec2
-	static multiply	= function( _vec ) {
-		return new Vec2( x * _vec.x, y * _vec.y );
-		
+	static componentwise_multiply	= function( _vec ) {
+		if (not struct_type(_vec, Vec2)) {
+			throw new UnexpectedTypeMismatch("componentwise_multiply", _vec, "Vec2");	
+		}
+		return set(x * _vec.x, y * _vec.y); 
 	}
 	/// @param {Vec2} vec	A vector
 	/// @desc	Divides this vector by vec and returns the result.
 	/// @returns Vec2
-	static divide	= function( _vec ) {
-		return new Vec2( x / _vec.x, y / _vec.y );
-		
+	static componentwise_divide	= function( _vec ) {
+		if (not struct_type(_vec, Vec2)) {
+			throw new UnexpectedTypeMismatch("componentwise_divide", _vec, "Vec2");	
+		}
+		if (_vec.x == 0 || _vec.y == 0) {
+			throw new DivisionByZero("componentwise_divide");
+		}
+		return set(x / _vec.x, y / _vec.y); 
 	}
 	/// @param {Vec2} vec	A vector
 	/// @desc	Returns the cross product this vector and vec.
 	/// @returns Vec2
 	static cross	= function( _vec ) {
+		if (not struct_type(_vec, Vec2)) {
+			throw new UnexpectedTypeMismatch("cross", _vec, "Vec2");	
+		}
 		return x * _vec.x - y * _vec.y;
-		
 	}
 	/// @desc	Returns this vector normallized to unit length.
 	/// @returns Vec2
 	static normalize	= function() {
-		var _len_sqr	= lensqr();
-		
-		if ( _len_sqr != 0 ) {
-			var _len	= sqrt( _len_sqr );
-			
-			return new Vec2( x / _len, y / _len );
-			
+		if (not struct_type(_vec, Vec2)) {
+			throw new UnexpectedTypeMismatch("normalize", _vec, "Vec2");	
 		}
-		throw new __Error__().from_string( "Vec2 length must be greater than 0 to normalize!" );
+		var _len = sqr_len();
+		if ( _len == 0 ) {
+			throw new DivisionByZero("normalize");
+		}
 		
+		_len = sqrt( _len );
+		return new Vec2( x / _len, y / _len );
+	}
+	/// @returns Vec3
+	/// @desc Used to get the vectors as unit length.
+	static normalized	= function() {
+		if (not struct_type(_vec, Vec2)) {
+			throw new UnexpectedTypeMismatch("normalized", _vec, "Vec2");	
+		}
+		var _len = sqr_len();
+		if ( _len == 0 ) {
+			throw new DivisionByZero("normalize");
+		}
+		_len = sqrt( _len );
+			
+		return new Vec2( x / _len, y / _len);
 	}
 	/// @param {Vec2} vec	A vector
 	/// @desc	Returns the dot product of this vector and vec.
 	/// @returns real
 	static dot	= function( _vec ) {
+		if (not struct_type(_vec, Vec2)) {
+			throw new UnexpectedTypeMismatch("dot", _vec, "Vec2");	
+		}
 		return x * _vec.x + y * _vec.y;
-		
 	}
 	/// @param {Vec2} vec	A vector
 	/// @desc	Returns the distance between this vector and vec.
 	/// @returns real
 	static dist_to	= function( _vec ) {
+		if (not struct_type(_vec, Vec2)) {
+			throw new UnexpectedTypeMismatch("dist_to", _vec, "Vec2");	
+		}
 		return sqrt((x - _vec.x) * (x - _vec.x) + (y - _vec.y) * (y - _vec.y));
-		
 	}	
 	/// @param {Vec2} vec	A vector
 	/// @desc	Returns the squared distance between this vector and vec.
 	/// @returns real
-	static dist_to_sqr	= function( _vec ) {
+	static sqr_dist_to	= function( _vec ) {
+		if (not struct_type(_vec, Vec2)) {
+			throw new UnexpectedTypeMismatch("sqr_dist_to", _vec, "Vec2");	
+		}
 		return ((x - _vec.x) * (x - _vec.x) + (y - _vec.y) * (y - _vec.y));
-		
 	}
 	/// @desc	Returns the length of this vector.
 	/// @returns real
 	static len	= function() {
 		return sqrt( x * x + y * y );
-		
 	}
 	/// @desc	Returns the squared length of this vector.
 	/// @returns real
-	static lensqr	= function() {
+	static sqr_len	= function() {
 		return (x * x + y * y);
-		
 	}
 	/// @param {real}	x	An x position
 	/// @param {real}	y	An y position
 	/// @desc	Set the x and y values of this vector.
 	/// @returns self
 	static set	= function( _x, _y ) {
+		if (not (is_real(_x) && is_real(_y))) {
+			throw new UnexpectedTypeMismatch("set", _vec, "real");	
+		}
 		x	= _x;
 		y	= _y;
 		
@@ -117,4 +151,6 @@ function Vec2( _x, _y ) constructor {
 	/// @var {real} the y position of this vector
 	y	= _y;
 	
+	
+	__Type__.add( Vec2 );
 }

--- a/scripts/Vec2/Vec2.gml
+++ b/scripts/Vec2/Vec2.gml
@@ -12,7 +12,7 @@ function Vec2( _x, _y ) : __Struct__() constructor {
 	/// @returns Vec2
 	static add	= function( _vec ) {
 		if (not struct_type(_vec, Vec2)) {
-			throw new UnexpectedTypeMismatch("add", _vec, "Vec2");	
+			throw new InvalidArgumentType("add", _vec, "Vec2");	
 		}
 		return set(x + _vec.x, y + _vec.y); 
 	}
@@ -21,7 +21,7 @@ function Vec2( _x, _y ) : __Struct__() constructor {
 	/// @returns Vec2
 	static subtract	= function( _vec ) {
 		if (not struct_type(_vec, Vec2)) {
-			throw new UnexpectedTypeMismatch("subtract", _vec, "Vec2");	
+			throw new InvalidArgumentType("subtract", _vec, "Vec2");	
 		}
 		return set(x - _vec.x, y - _vec.y); 
 	}
@@ -30,7 +30,7 @@ function Vec2( _x, _y ) : __Struct__() constructor {
 	/// @returns Vec2
 	static componentwise_multiply	= function( _vec ) {
 		if (not struct_type(_vec, Vec2)) {
-			throw new UnexpectedTypeMismatch("componentwise_multiply", _vec, "Vec2");	
+			throw new InvalidArgumentType("componentwise_multiply", _vec, "Vec2");	
 		}
 		return set(x * _vec.x, y * _vec.y); 
 	}
@@ -39,7 +39,7 @@ function Vec2( _x, _y ) : __Struct__() constructor {
 	/// @returns Vec2
 	static componentwise_divide	= function( _vec ) {
 		if (not struct_type(_vec, Vec2)) {
-			throw new UnexpectedTypeMismatch("componentwise_divide", _vec, "Vec2");	
+			throw new InvalidArgumentType("componentwise_divide", _vec, "Vec2");	
 		}
 		if (_vec.x == 0 || _vec.y == 0) {
 			throw new DivisionByZero("componentwise_divide");
@@ -51,15 +51,24 @@ function Vec2( _x, _y ) : __Struct__() constructor {
 	/// @returns Vec2
 	static cross	= function( _vec ) {
 		if (not struct_type(_vec, Vec2)) {
-			throw new UnexpectedTypeMismatch("cross", _vec, "Vec2");	
+			throw new InvalidArgumentType("cross", _vec, "Vec2");	
 		}
 		return x * _vec.x - y * _vec.y;
+	}
+	/// @param {Vec2} vec	A vector
+	/// @desc	Returns the dot product of this vector and vec.
+	/// @returns real
+	static dot	= function( _vec ) {
+		if (not struct_type(_vec, Vec2)) {
+			throw new InvalidArgumentType("dot", _vec, "Vec2");	
+		}
+		return x * _vec.x + y * _vec.y;
 	}
 	/// @desc	Returns this vector normallized to unit length.
 	/// @returns Vec2
 	static normalize	= function() {
 		if (not struct_type(_vec, Vec2)) {
-			throw new UnexpectedTypeMismatch("normalize", _vec, "Vec2");	
+			throw new InvalidArgumentType("normalize", _vec, "Vec2");	
 		}
 		var _len = sqr_len();
 		if ( _len == 0 ) {
@@ -73,7 +82,7 @@ function Vec2( _x, _y ) : __Struct__() constructor {
 	/// @desc Used to get the vectors as unit length.
 	static normalized	= function() {
 		if (not struct_type(_vec, Vec2)) {
-			throw new UnexpectedTypeMismatch("normalized", _vec, "Vec2");	
+			throw new InvalidArgumentType("normalized", _vec, "Vec2");	
 		}
 		var _len = sqr_len();
 		if ( _len == 0 ) {
@@ -84,20 +93,11 @@ function Vec2( _x, _y ) : __Struct__() constructor {
 		return new Vec2( x / _len, y / _len);
 	}
 	/// @param {Vec2} vec	A vector
-	/// @desc	Returns the dot product of this vector and vec.
-	/// @returns real
-	static dot	= function( _vec ) {
-		if (not struct_type(_vec, Vec2)) {
-			throw new UnexpectedTypeMismatch("dot", _vec, "Vec2");	
-		}
-		return x * _vec.x + y * _vec.y;
-	}
-	/// @param {Vec2} vec	A vector
 	/// @desc	Returns the distance between this vector and vec.
 	/// @returns real
 	static dist_to	= function( _vec ) {
 		if (not struct_type(_vec, Vec2)) {
-			throw new UnexpectedTypeMismatch("dist_to", _vec, "Vec2");	
+			throw new InvalidArgumentType("dist_to", _vec, "Vec2");	
 		}
 		return sqrt((x - _vec.x) * (x - _vec.x) + (y - _vec.y) * (y - _vec.y));
 	}	
@@ -106,7 +106,7 @@ function Vec2( _x, _y ) : __Struct__() constructor {
 	/// @returns real
 	static sqr_dist_to	= function( _vec ) {
 		if (not struct_type(_vec, Vec2)) {
-			throw new UnexpectedTypeMismatch("sqr_dist_to", _vec, "Vec2");	
+			throw new InvalidArgumentType("sqr_dist_to", _vec, "Vec2");	
 		}
 		return ((x - _vec.x) * (x - _vec.x) + (y - _vec.y) * (y - _vec.y));
 	}
@@ -126,7 +126,7 @@ function Vec2( _x, _y ) : __Struct__() constructor {
 	/// @returns self
 	static set	= function( _x, _y ) {
 		if (not (is_real(_x) && is_real(_y))) {
-			throw new UnexpectedTypeMismatch("set", _vec, "real");	
+			throw new InvalidArgumentType("set", _vec, "real");	
 		}
 		x	= _x;
 		y	= _y;

--- a/scripts/Vec3/Vec3.gml
+++ b/scripts/Vec3/Vec3.gml
@@ -4,9 +4,9 @@
 /// @param {real} z The z component in this vector
 /// @desc A simple, garbage-collected three-dimensional vector.
 /// @example
-//var _vec3 = new Vec3( 32, 20, 12 );
+//var _vec = new Vec3( 32, 20, 12 );
 /// @wiki Core-Index
-function Vec3( _x, _y, _z ) constructor {
+function Vec3( _x, _y, _z ) : __Struct__() constructor {
 	/// @param {real} x The x component to set this vector
 	/// @param {real} y The y component to set this vector
 	/// @param {real} z The z component to set this vector
@@ -23,78 +23,109 @@ function Vec3( _x, _y, _z ) constructor {
 	}
 	/// @returns real
 	/// @desc Used to get the vectors squared length.
-	static lensqr	= function() {
+	static sqr_len	= function() {
 		return (x * x + y * y + z * z);	
 	}
 	/// @param {Vec3} Vec3 The vector to add to this one.
 	/// @returns Vec3
-	static add	= function( _Vec3 ) { return new Vec3( x + _Vec3.x, y + _Vec3.y, z + _Vec3.z ); }
+	static add	= function( _vec ) {
+		if (not struct_type(_vec, Vec3)) {
+			throw new UnexpectedTypeMismatch("add", _vec, "Vec3");	
+		}
+		return set( x + _vec.x, y + _vec.y, z + _vec.z ); 
+	}
 	/// @param {Vec3} Vec3 The vector to subtract from this one.
 	/// @returns Vec3
-	static subtract	= function( _Vec3 ) {
-		return new Vec3(  x	- _Vec3.x, y - _Vec3.y, z - _Vec3.z );
-		
+	static subtract	= function( _vec ) {
+		if (not struct_type(_vec, Vec3)) {
+			throw new UnexpectedTypeMismatch("subtract", _vec, "Vec3");	
+		}
+		return set(  x	- _vec.x, y - _vec.y, z - _vec.z );
 	}
 	/// @param {Vec3} Vec3 The vector to multiply this one component wise with.
 	/// @returns Vec3
-	static multiply	= function( _Vec3 ) {
-		return new Vec3( x * _Vec3.x, y * _Vec3.y, z * _Vec3.z );
-		
+	static componentwise_multiply = function( _vec ) {
+		if (not struct_type(_vec, Vec3)) {
+			throw new UnexpectedTypeMismatch("componentwise_multiply", _vec, "Vec3");	
+		}
+		return set( x * _vec.x, y * _vec.y, z * _vec.z );
 	}
 	/// @param {Vec3} Vec3 The vector to divide this one one component wise by.
 	/// @returns Vec3
-	static divide	= function( _Vec3 ) {
-		return new Vec3( x / _Vec3.x, y / _Vec3.y, z / _Vec3.z );
-		
+	static componentwise_divide	= function( _vec ) {
+		if (not struct_type(_vec, Vec3)) {
+			throw new UnexpectedTypeMismatch("componentwise_divide", _vec, "Vec3");	
+		}
+		if (_vec.x == 0 || _vec.y == 0 || _vec.z == 0) {
+			throw new DivisionByZero("componentwise_divide");
+		}
+		return new Vec3( x / _vec.x, y / _vec.y, z / _vec.z );
 	}
 	/// @param {Vec3} Vec3 The vector to get the dot product with.
 	/// @returns real
-	static dot	= function( _Vec3 ) {
-		return x * _Vec3.x + y * _Vec3.y + z * _Vec3.z;
-		
+	static dot	= function( _vec ) {
+		if (not struct_type(_vec, Vec3)) {
+			throw new UnexpectedTypeMismatch("dot", _vec, "Vec3");	
+		}
+		return x * _vec.x + y * _vec.y + z * _vec.z;
 	}
 	/// @param {Vec3} Vec3 The vector to get the cross product with.
 	/// @returns Vec3
-	static cross	= function( _Vec3 ) {
-		var _x = y * _Vec3.z - z * _Vec3.y;
-		var _y = z * _Vec3.x - x * _Vec3.z;
-		var _z = x * _Vec3.y - y * _Vec3.x;
+	static cross	= function( _vec ) {
+		if (not struct_type(_vec, Vec3)) {
+			throw new UnexpectedTypeMismatch("cross", _vec, "Vec3");	
+		}
+		var _x = y * _vec.z - z * _vec.y;
+		var _y = z * _vec.x - x * _vec.z;
+		var _z = x * _vec.y - y * _vec.x;
 		return new Vec3(_x, _y, _z);
 	}
 	/// @param {Vec3} Vec3 The vector to get the distance to.
 	/// @returns real
-	static dist_to	= function( _Vec3 ) {
+	static dist_to	= function( _vec ) {
+		if (not struct_type(_vec, Vec3)) {
+			throw new UnexpectedTypeMismatch("dist_to", _vec, "Vec3");	
+		}
 		return sqrt(
-			(x - _Vec3.x) * (x - _Vec3.x) +
-			(y - _Vec3.y) * (y - _Vec3.y) +
-			(z - _Vec3.z) * (z - _Vec3.z)
+			(x - _vec.x) * (x - _vec.x) +
+			(y - _vec.y) * (y - _vec.y) +
+			(z - _vec.z) * (z - _vec.z)
 		);
 	}	
 	/// @param {Vec3} Vec3 The vector to get the squared distance to.
 	/// @returns real
-	static dist_to_sqr	= function( _Vec3 ) {
+	static sqr_dist_to	= function( _vec ) {
+		if (not struct_type(_vec, Vec3)) {
+			throw new UnexpectedTypeMismatch("sqr_dist_to", _vec, "Vec3");	
+		}
 		return ( 
-			(x - _Vec3.x) * (x - _Vec3.x) +
-			(y - _Vec3.y) * (y - _Vec3.y) +
-			(z - _Vec3.z) * (z - _Vec3.z)
+			(x - _vec.x) * (x - _vec.x) +
+			(y - _vec.y) * (y - _vec.y) +
+			(z - _vec.z) * (z - _vec.z)
 		);
 	}
 
 	/// @returns Vec3
 	/// @desc Used to normalise the vector to unit length.
 	static normalize	= function() {
-		var _len		= 0;
-			_len	= sqrt( _len );
-			
-			set( x / _len, y / _len, z / _len);
-
-		return self;
+		var _len		= sqr_len();
+		if (_len == 0) 
+			throw new DivisionByZero("normalize");
+		}
+		_len	= sqrt( _len );
+		return set( x / _len, y / _len, z / _len);
 	}
 	/// @returns Vec3
-	/// @desc Used to get the vectors unit length.
+	/// @desc Used to get the vectors as unit length.
 	static normalized	= function() {
-		var _len		= 0;
-			_len	= sqrt( _len );
+		if (not struct_type(_vec, Vec3)) {
+			throw new UnexpectedTypeMismatch("normalized", _vec, "Vec3");	
+		}
+		var _len = sqr_len();
+		if ( _len == 0 ) {
+			throw new DivisionByZero("normalize");
+		}
+		_len = sqrt( _len );
 			
 		return new Vec3( x / _len, y / _len, z / _len);
 	}
@@ -110,10 +141,7 @@ function Vec3( _x, _y, _z ) constructor {
 		return string( x ) + ", " + string( y ) + ", " + string( z );
 		
 	}
-	static is		= function( _data_type ) {
-		return _data_type == Vec3;
-		
-	}
+
 	/// @desc the x component of this vector
 	x	= 0;
 	/// @desc the y component of this vector
@@ -122,4 +150,5 @@ function Vec3( _x, _y, _z ) constructor {
 	z	= 0;
 	set( _x, _y, _z );
 	
+	__Type__.add( Vec3 );
 }

--- a/scripts/Vec3/Vec3.gml
+++ b/scripts/Vec3/Vec3.gml
@@ -109,7 +109,7 @@ function Vec3( _x, _y, _z ) : __Struct__() constructor {
 	/// @desc Used to normalise the vector to unit length.
 	static normalize	= function() {
 		var _len		= sqr_len();
-		if (_len == 0) 
+		if (_len == 0) {
 			throw new DivisionByZero("normalize");
 		}
 		_len	= sqrt( _len );

--- a/scripts/Vec3/Vec3.gml
+++ b/scripts/Vec3/Vec3.gml
@@ -30,7 +30,7 @@ function Vec3( _x, _y, _z ) : __Struct__() constructor {
 	/// @returns Vec3
 	static add	= function( _vec ) {
 		if (not struct_type(_vec, Vec3)) {
-			throw new UnexpectedTypeMismatch("add", _vec, "Vec3");	
+			throw new InvalidArgumentType("add", _vec, "Vec3");	
 		}
 		return set( x + _vec.x, y + _vec.y, z + _vec.z ); 
 	}
@@ -38,7 +38,7 @@ function Vec3( _x, _y, _z ) : __Struct__() constructor {
 	/// @returns Vec3
 	static subtract	= function( _vec ) {
 		if (not struct_type(_vec, Vec3)) {
-			throw new UnexpectedTypeMismatch("subtract", _vec, "Vec3");	
+			throw new InvalidArgumentType("subtract", _vec, "Vec3");	
 		}
 		return set(  x	- _vec.x, y - _vec.y, z - _vec.z );
 	}
@@ -46,7 +46,7 @@ function Vec3( _x, _y, _z ) : __Struct__() constructor {
 	/// @returns Vec3
 	static componentwise_multiply = function( _vec ) {
 		if (not struct_type(_vec, Vec3)) {
-			throw new UnexpectedTypeMismatch("componentwise_multiply", _vec, "Vec3");	
+			throw new InvalidArgumentType("componentwise_multiply", _vec, "Vec3");	
 		}
 		return set( x * _vec.x, y * _vec.y, z * _vec.z );
 	}
@@ -54,7 +54,7 @@ function Vec3( _x, _y, _z ) : __Struct__() constructor {
 	/// @returns Vec3
 	static componentwise_divide	= function( _vec ) {
 		if (not struct_type(_vec, Vec3)) {
-			throw new UnexpectedTypeMismatch("componentwise_divide", _vec, "Vec3");	
+			throw new InvalidArgumentType("componentwise_divide", _vec, "Vec3");	
 		}
 		if (_vec.x == 0 || _vec.y == 0 || _vec.z == 0) {
 			throw new DivisionByZero("componentwise_divide");
@@ -65,7 +65,7 @@ function Vec3( _x, _y, _z ) : __Struct__() constructor {
 	/// @returns real
 	static dot	= function( _vec ) {
 		if (not struct_type(_vec, Vec3)) {
-			throw new UnexpectedTypeMismatch("dot", _vec, "Vec3");	
+			throw new InvalidArgumentType("dot", _vec, "Vec3");	
 		}
 		return x * _vec.x + y * _vec.y + z * _vec.z;
 	}
@@ -73,7 +73,7 @@ function Vec3( _x, _y, _z ) : __Struct__() constructor {
 	/// @returns Vec3
 	static cross	= function( _vec ) {
 		if (not struct_type(_vec, Vec3)) {
-			throw new UnexpectedTypeMismatch("cross", _vec, "Vec3");	
+			throw new InvalidArgumentType("cross", _vec, "Vec3");	
 		}
 		var _x = y * _vec.z - z * _vec.y;
 		var _y = z * _vec.x - x * _vec.z;
@@ -84,7 +84,7 @@ function Vec3( _x, _y, _z ) : __Struct__() constructor {
 	/// @returns real
 	static dist_to	= function( _vec ) {
 		if (not struct_type(_vec, Vec3)) {
-			throw new UnexpectedTypeMismatch("dist_to", _vec, "Vec3");	
+			throw new InvalidArgumentType("dist_to", _vec, "Vec3");	
 		}
 		return sqrt(
 			(x - _vec.x) * (x - _vec.x) +
@@ -96,7 +96,7 @@ function Vec3( _x, _y, _z ) : __Struct__() constructor {
 	/// @returns real
 	static sqr_dist_to	= function( _vec ) {
 		if (not struct_type(_vec, Vec3)) {
-			throw new UnexpectedTypeMismatch("sqr_dist_to", _vec, "Vec3");	
+			throw new InvalidArgumentType("sqr_dist_to", _vec, "Vec3");	
 		}
 		return ( 
 			(x - _vec.x) * (x - _vec.x) +
@@ -119,7 +119,7 @@ function Vec3( _x, _y, _z ) : __Struct__() constructor {
 	/// @desc Used to get the vectors as unit length.
 	static normalized	= function() {
 		if (not struct_type(_vec, Vec3)) {
-			throw new UnexpectedTypeMismatch("normalized", _vec, "Vec3");	
+			throw new InvalidArgumentType("normalized", _vec, "Vec3");	
 		}
 		var _len = sqr_len();
 		if ( _len == 0 ) {

--- a/scripts/__FAST_config__/__FAST_config__.gml
+++ b/scripts/__FAST_config__/__FAST_config__.gml
@@ -252,3 +252,7 @@ function ReservedKeyword( _call, _value ) : __Error__() constructor {
 function IllegalStreamOperation( _call, _msg ) : __Error__() constructor {
 	message	= f( "The function {} failed because {}.", _call, _msg );
 }
+
+function DivisionByZero( _call ) : __Error__() constructor {
+	message	= f( "Divide by zero encountered. {}", _call, _msg );
+}


### PR DESCRIPTION
- New Error Type (DivisionByZero)
- Fixed a couple Vec2 operations not setting the Vec2's values but rather returning a Vec2 with the correct values (add, subtract, multiply, divide, normalise)
```js
Before : 
a = new Vec2( 1, 1);
b = new Vec2( 1, 1);
a = a.add(b);
Now :
a = new Vec2( 1, 1);
b = new Vec2( 1, 1);
a.add(b);
```
- Fixed a couple Vec3 operations not setting the Vec3's values but rather returning a Vec3 with the correct values (add, subtract, multiply, divide, normalise) (see above)
- Fixed Vec3.normalise and Vec3.normalised always returning 0
- Added Vec2.normalised
- Changed Vec2 and Vec3 to inherit from __Struct__
- Added Type checking to Vec2 and Vec3
